### PR TITLE
Rename controlled_access_terms_default_configuration: Issue 1132

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: true
+dist: trusty
 language: php
 php:
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "islandora/islandora": "dev-8.x-1.x",
     "islandora/openseadragon" : "dev-8.x-1.x",
-    "islandora/controlled_access_terms" : "dev-8.x-1.x",
+    "islandora/controlled_access_terms" : "dev-issue-1132",
     "drupal/field_group" : "^3.0",
     "drupal/permissions_by_term" : "^1.51",
     "drupal/field_permissions" : "^1.0"

--- a/islandora_defaults.info.yml
+++ b/islandora_defaults.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - content_translation
   - context
   - controlled_access_terms
-  - controlled_access_terms_default_configuration
+  - controlled_access_terms_defaults
   - eva
   - field
   - field_group


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1132

# What does this Pull Request do?

Renames 'controlled_access_terms_default_configuration' to 'controlled_access_terms_defaults'.

# What's new?

* Renames 'controlled_access_terms_default_configuration' to 'controlled_access_terms_defaults'.
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No.

# How should this be tested?

Test with Islandora-Devops/claw-playbook/pull/112.

# Additional Notes:
Once this is tested and Islandora-CLAW/controlled_access_terms/pull/29 is merged we need to revert `"islandora/controlled_access_terms" : "dev-issue-1132"` in composer.json back to `"islandora/controlled_access_terms" : "dev-8.x-1.x"` before merging.

*Update: ready to merge.*

# Interested parties
@dannylamb, @Islandora-CLAW/committers