### PR TITLE
Change field_media_use to checkboxes

### DIFF
--- a/config/install/core.entity_form_display.media.audio.default.yml
+++ b/config/install/core.entity_form_display.media.audio.default.yml
@@ -46,7 +46,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_media_use:
-    type: options_select
+    type: options_buttons
     weight: 2
     region: content
     settings: {  }

--- a/config/install/core.entity_form_display.media.file.default.yml
+++ b/config/install/core.entity_form_display.media.file.default.yml
@@ -46,7 +46,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_media_use:
-    type: options_select
+    type: options_buttons
     weight: 2
     region: content
     settings: {  }

--- a/config/install/core.entity_form_display.media.image.default.yml
+++ b/config/install/core.entity_form_display.media.image.default.yml
@@ -50,7 +50,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_media_use:
-    type: options_select
+    type: options_buttons
     weight: 2
     region: content
     settings: {  }

--- a/config/install/core.entity_form_display.media.video.default.yml
+++ b/config/install/core.entity_form_display.media.video.default.yml
@@ -39,7 +39,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_media_use:
-    type: options_select
+    type: options_buttons
     weight: 2
     region: content
     settings: {  }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1142

Test with https://github.com/Islandora-CLAW/islandora/pull/143

# What does this Pull Request do?

Changes the field_media_use form widget to use checkboxes instead of the select box.

# What's new?

* Changes `options_select` to `options_buttons` for audio, file, image, and video.
* Does this change require documentation to be updated? Maybe...
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Apply the PR (to a site with content or an empty site, doesn't matter which).
* Feature import.
* See the checkboxes for field_media_use when creating a media instead of a select box.

# Interested parties
@dannylamb, @Islandora-CLAW/committers
