### PR TITLE
Add help text for Media Use field on the four standard media types

### DIFF
--- a/config/install/field.field.media.audio.field_media_use.yml
+++ b/config/install/field.field.media.audio.field_media_use.yml
@@ -6,9 +6,9 @@ dependencies:
     - media.type.audio
     - taxonomy.vocabulary.islandora_media_use
   content:
-    - 'taxonomy_term:islandora_media_use:550e8f91-2214-4f3d-88c6-6552f44b2b81'
+    - 'taxonomy_term:islandora_media_use:fe4c8b44-b230-45df-a7b5-62794f9b3b01'
 _core:
-  default_config_hash: ZSdgdnlaHn9SQJzAd4ZgJqQ8uCUA3wf4OQNRxaPL4d0
+  default_config_hash: _Z9k59ERH4xZEDu82qUWLlMMptINa_nX1vR8K1gKpPU
 id: media.audio.field_media_use
 field_name: field_media_use
 entity_type: media
@@ -19,7 +19,7 @@ required: false
 translatable: false
 default_value:
   -
-    target_uuid: 550e8f91-2214-4f3d-88c6-6552f44b2b81
+    target_uuid: fe4c8b44-b230-45df-a7b5-62794f9b3b01
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/config/install/field.field.media.audio.field_media_use.yml
+++ b/config/install/field.field.media.audio.field_media_use.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.audio
+    - taxonomy.vocabulary.islandora_media_use
+  content:
+    - 'taxonomy_term:islandora_media_use:550e8f91-2214-4f3d-88c6-6552f44b2b81'
+_core:
+  default_config_hash: ZSdgdnlaHn9SQJzAd4ZgJqQ8uCUA3wf4OQNRxaPL4d0
+id: media.audio.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: audio
+label: 'Media Use'
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
+required: false
+translatable: false
+default_value:
+  -
+    target_uuid: 550e8f91-2214-4f3d-88c6-6552f44b2b81
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.media.file.field_media_use.yml
+++ b/config/install/field.field.media.file.field_media_use.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.file
+    - taxonomy.vocabulary.islandora_media_use
+  content:
+    - 'taxonomy_term:islandora_media_use:fe4c8b44-b230-45df-a7b5-62794f9b3b01'
+_core:
+  default_config_hash: RaJdzQa8hxS5bioyZfORM9BoTGzhkgt7bcV1ht48OQg
+id: media.file.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: file
+label: 'Media Use'
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
+required: false
+translatable: true
+default_value:
+  -
+    target_uuid: fe4c8b44-b230-45df-a7b5-62794f9b3b01
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.media.image.field_media_use.yml
+++ b/config/install/field.field.media.image.field_media_use.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.image
+    - taxonomy.vocabulary.islandora_media_use
+  content:
+    - 'taxonomy_term:islandora_media_use:fe4c8b44-b230-45df-a7b5-62794f9b3b01'
+_core:
+  default_config_hash: czUe39uQUc4HK-JU_cy-dPIMCfNQJdvd-ln8rRNySEs
+id: media.image.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: image
+label: 'Media Use'
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
+required: false
+translatable: true
+default_value:
+  -
+    target_uuid: fe4c8b44-b230-45df-a7b5-62794f9b3b01
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.media.video.field_media_use.yml
+++ b/config/install/field.field.media.video.field_media_use.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.video
+    - taxonomy.vocabulary.islandora_media_use
+  content:
+    - 'taxonomy_term:islandora_media_use:fe4c8b44-b230-45df-a7b5-62794f9b3b01'
+_core:
+  default_config_hash: edwWb7GuvSOr4MWenMMVfLPyvKMoAhxHwjGCpeKO5GA
+id: media.video.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: video
+label: 'Media Use'
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
+required: false
+translatable: true
+default_value:
+  -
+    target_uuid: fe4c8b44-b230-45df-a7b5-62794f9b3b01
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1186

# What does this Pull Request do?

Adds a bit of help text to the Media Use field to explain which selection generates derivatives, and how to find out more.

`Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. 'Original File' will trigger creation of derivatives.`

# How should this be tested?

Pull in the changes and do a feature import (`drush fim -y islandora_core_feature`), then go try to add new Media in each of the existing types, verifying that the help text appears.

# Additional notes
Doing this, I learned a ton about how to translate front-end configuration into something that can be rendered into a pull request, including how to point a GUI file manager at an Islandora 8 VM running in Virtual Box (because vim is terrifying). Documentation for other front-endians to follow when I polish it up.

# Interested parties
@seth-shaw-unlv @mjordan 
