### PR TITLE
Initial OAI-PMH Endpoint (issues 498 & 1192)

### DIFF
--- a/modules/islandora_oaipmh/README.md
+++ b/modules/islandora_oaipmh/README.md
@@ -1,0 +1,28 @@
+# Islandora OAI-PMH Endpoint
+
+This submodule leverages the [rest\_oai\_pmh module](https://www.drupal.org/project/rest_oai_pmh)
+to provide an OAI-PMH endpoint to allow harvesting repository content.
+
+By default the OAI-PMH endpoint is located at 'yoursite.example/oai/request'
+and includes a set identified as 'oai\_pmh:all\_repository\_items' which can be
+further configured by editing the provided OAI-PMH view. The provided set 
+includes all items using the 'repository item' content model that _don't_ use 
+the 'Collection' model. Additional sets can be created by making views with the
+Entity Reference view display mode and enabling them on the rest\_oai\_pmh
+configuration page: `/admin/config/services/rest/oai-pmh`. The module can use
+any view using an Entity Reference view display mode, they do not need to be
+part of the provided OAI-PMH view, it is simply available as a convenience.
+
+The rest\_oai\_pmh module indexes set membership, so repository items may not appear
+immediately in their respective sets. Indexing will happen automatically during
+cron runs but can be triggered manually at `/admin/config/services/rest/oai-pmh/queue`.
+
+This module uses the Dublin Core metadata defined by
+the [repository item content model's RDF mapping](http://islandora-claw.github.io/CLAW/user-documentation/content_types/#update-create-an-rdf-mapping).
+However, the RDF mapping does not include support for islandora\_default's use
+of the linked agent field. Including agent links in the OAI-PMH metadata
+currently requires updating the RDF mapping to include a Dublin Core predicate
+for that field or any other additional fields. 
+The rest\_oai\_pmh module also supports defining mappings using the
+[metatag\ module](https://www.drupal.org/project/metatag) or creating a custom
+metadata profile using the Twig templating system.

--- a/modules/islandora_oaipmh/README.md
+++ b/modules/islandora_oaipmh/README.md
@@ -6,7 +6,7 @@ to provide an OAI-PMH endpoint to allow harvesting repository content.
 By default the OAI-PMH endpoint is located at 'yoursite.example/oai/request'
 and includes a set identified as 'oai\_pmh:all\_repository\_items' which can be
 further configured by editing the provided OAI-PMH view. The provided set 
-includes all items using the 'repository item' content model that _don't_ use 
+includes all items using the 'repository item' content type that _don't_ use 
 the 'Collection' model. Additional sets can be created by making views with the
 Entity Reference view display mode and enabling them on the rest\_oai\_pmh
 configuration page: `/admin/config/services/rest/oai-pmh`. The module can use
@@ -26,3 +26,12 @@ for that field or any other additional fields. Alternatively, the rest\_oai\_pmh
 also supports defining mappings with the
 [metatag module](https://www.drupal.org/project/metatag) or creating a custom
 metadata profile using the Twig templating system.
+
+## Configuration
+
+1. Install rest\_oai\_pmh (e.g. `composer require drupal/rest\_oai\_pmh`).
+1. Enable this module (e.g. `drush en -y islandora\_oaipmh`).
+1. Trigger the OAI-PMH indexer: Click the button found on the page at `http://localhost:8000/admin/config/services/rest/oai-pmh/queue` (or wait for cron)
+1. Give anonymous users the "Access GET on OAI-PMH resource" permission.
+
+Your OAI-PMH Endpoint should now be ready. e.g. `http://localhost:8000/oai/request?verb=ListRecords&metadataPrefix=oai\_dc`

--- a/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
+++ b/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
@@ -1,6 +1,5 @@
 rest_oai_pmh:
   entity_type: node
-_core:
 view_displays:
   'oai_pmh:all_repository_items': 'oai_pmh:all_repository_items'
 support_sets: 1

--- a/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
+++ b/modules/islandora_oaipmh/config/install/rest_oai_pmh.settings.yml
@@ -1,0 +1,10 @@
+rest_oai_pmh:
+  entity_type: node
+_core:
+view_displays:
+  'oai_pmh:all_repository_items': 'oai_pmh:all_repository_items'
+support_sets: 1
+mapping_source: rdf
+repository_name: 'Islandora 8'
+repository_email: admin@example.com
+expiration: '3600'

--- a/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
+++ b/modules/islandora_oaipmh/config/install/views.view.oai_pmh.yml
@@ -1,0 +1,254 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+  module:
+    - node
+    - taxonomy
+    - user
+id: oai_pmh
+label: OAI-PMH
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            islandora_object: islandora_object
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_external_uri_uri:
+          id: field_external_uri_uri
+          table: taxonomy_term__field_external_uri
+          field: field_external_uri_uri
+          relationship: field_model
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: 'http://purl.org/dc/dcmitype/Collection'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        field_model:
+          id: field_model
+          table: node__field_model
+          field: field_model
+          relationship: none
+          group_type: group
+          admin_label: 'field_model: Taxonomy term'
+          required: false
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  all_repository_items:
+    display_plugin: entity_reference
+    id: all_repository_items
+    display_title: 'All Repository Items'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+

--- a/modules/islandora_oaipmh/islandora_oaipmh.features.yml
+++ b/modules/islandora_oaipmh/islandora_oaipmh.features.yml
@@ -1,0 +1,1 @@
+bundle: islandora

--- a/modules/islandora_oaipmh/islandora_oaipmh.info.yml
+++ b/modules/islandora_oaipmh/islandora_oaipmh.info.yml
@@ -1,0 +1,8 @@
+name: 'Islandora OAI-PMH Endpoint'
+type: module
+description: 'Default configuration for an OAI-PMH Endpoint'
+core: 8.x
+package: 'Islandora'
+dependencies:
+  - rest_oai_pmh
+  - islandora_defaults

--- a/modules/islandora_oaipmh/islandora_oaipmh.module
+++ b/modules/islandora_oaipmh/islandora_oaipmh.module
@@ -1,0 +1,19 @@
+<?php
+
+function islandora_oaipmh_preprocess_rest_oai_pmh_record(&$variables) {
+  $entity = $variables['entity'];
+  if ($entity->hasField('field_linked_agent')) {
+    foreach ($entity->get('field_linked_agent') as $linked_agent) {
+      $creator_rels = [
+      	'relators:cre',
+	'relators:art',
+	'relators:aut',
+	'relators:edc',
+	'relators:pht',
+	'relators:trl',
+      ];
+      $dc_field = in_array($linked_agent->rel_type, $creator_rels)  ? 'dc:creator' : 'dc:contributor';
+      $variables['elements'][$dc_field][] = $linked_agent->entity->label();
+    }
+  }
+}

--- a/modules/islandora_oaipmh/islandora_oaipmh.module
+++ b/modules/islandora_oaipmh/islandora_oaipmh.module
@@ -1,18 +1,26 @@
 <?php
 
+/**
+ * @file
+ * Supports Islandora submodule islandora_oaipmh.
+ */
+
+/**
+ * Implements hook_preprocess_rest_oai_pmh_record().
+ */
 function islandora_oaipmh_preprocess_rest_oai_pmh_record(&$variables) {
   $entity = $variables['entity'];
   if ($entity->hasField('field_linked_agent')) {
     foreach ($entity->get('field_linked_agent') as $linked_agent) {
       $creator_rels = [
-      	'relators:cre',
-	'relators:art',
-	'relators:aut',
-	'relators:edc',
-	'relators:pht',
-	'relators:trl',
+        'relators:cre',
+        'relators:art',
+        'relators:aut',
+        'relators:edc',
+        'relators:pht',
+        'relators:trl',
       ];
-      $dc_field = in_array($linked_agent->rel_type, $creator_rels)  ? 'dc:creator' : 'dc:contributor';
+      $dc_field = in_array($linked_agent->rel_type, $creator_rels) ? 'dc:creator' : 'dc:contributor';
       $variables['elements'][$dc_field][] = $linked_agent->entity->label();
     }
   }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1192

This PR represents the ['short term' solution](https://github.com/Islandora-CLAW/CLAW/issues/1192#issuecomment-506501554) described in the issue thread.

# What does this Pull Request do?

Adds an islandora_oaipmh submodule using [rest_oai_pmh](https://www.drupal.org/project/rest_oai_pmh) to enable an OAI-PMH endpoint. Includes a README providing details about how it works.

# What's new?
* Added _the submodule_.
* Does this change require documentation to be updated? Perhaps adding a page to the Islandora docs?
* Does this change add any new dependencies? Only if the module is enabled; requires rest_oai_pmh.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

- Make some repository items (if you don't have any already).
- Apply the PR
- Install rest_oai_pmh (e.g. `composer require drupal/rest_oai_pmh`)
- Enable the module: `drush en -y islandora_oaipmh`
- Trigger the OAI-PMH indexer: Click the button found on the page at 'http://localhost:8000/admin/config/services/rest/oai-pmh/queue' (or wait for cron)
- Query the OAI-PMH Endpoint. E.g. `http://localhost:8000/oai/request?verb=ListRecords&metadataPrefix=oai_dc`

Bonus:
- (Read the README first...)
- Add an Entity Reference display mode to any existing view you have of.
- Add the new display mode as a set on the OAI-PMH configuration page.
- Trigger the OAI-PMH indexer
- See your set in the endpoint. 'http://localhost:8000/oai/request?verb=ListSets'

# Additional Notes:

The linked agents field complicates the mapping to Dublin Core. This module makes some assumptions in islandora_oaipmh_preprocess_rest_oai_pmh_record() (in islandora_oaipmh.module) about [which MARC relators are creators](https://github.com/seth-shaw-unlv/islandora_defaults/blob/issue-498/modules/islandora_oaipmh/islandora_oaipmh.module#L15-L22) and assumes the rest are contributors. If someone could specifically review that list (e.g. @rosiel), that would be great.

@joecorall [indicated the rest_oai_pmh module is still in alpha](https://github.com/Islandora-CLAW/CLAW/issues/1192#issuecomment-506427459) pending handling of deleted content. I personally don't think that should stop us from making it available. Although, I should probably add a note about it's experimental status in the README... I can also close the request if we think this is too soon.

# Interested parties
@Islandora-CLAW/committers
