### PR TITLE
Use weight field type for field_weight (Issue-1262)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "islandora/controlled_access_terms" : "dev-8.x-1.x",
     "drupal/field_group" : "^3.0",
     "drupal/permissions_by_term" : "^1.51",
-    "drupal/field_permissions" : "^1.0"
+    "drupal/field_permissions" : "^1.0",
+    "drupal/weight": "^3.1"
   }
 }

--- a/config/install/field.field.node.islandora_object.field_weight.yml
+++ b/config/install/field.field.node.islandora_object.field_weight.yml
@@ -4,6 +4,8 @@ dependencies:
   config:
     - field.storage.node.field_weight
     - node.type.islandora_object
+  module:
+    - weight
 id: node.islandora_object.field_weight
 field_name: field_weight
 entity_type: node
@@ -12,11 +14,10 @@ label: Weight
 description: 'Indicates the order of a resource in a collection of resources.'
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: '0'
 default_value_callback: ''
 settings:
-  min: 1
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: integer
+  range: '1000'
+field_type: weight

--- a/config/install/field.storage.node.field_weight.yml
+++ b/config/install/field.storage.node.field_weight.yml
@@ -4,20 +4,20 @@ dependencies:
   module:
     - field_permissions
     - node
+    - weight
 third_party_settings:
   field_permissions:
     permission_type: public
 id: node.field_weight
 field_name: field_weight
 entity_type: node
-type: integer
+type: weight
 settings:
   unsigned: false
-  size: normal
-module: core
+module: weight
 locked: false
 cardinality: 1
-translatable: true
+translatable: false
 indexes: {  }
 persist_with_no_fields: false
 custom_storage: false

--- a/config/install/rdf.mapping.node.islandora_object.yml
+++ b/config/install/rdf.mapping.node.islandora_object.yml
@@ -13,6 +13,7 @@ targetEntityType: node
 bundle: islandora_object
 types:
   - 'pcdm:Object'
+  - 'schema:CreativeWork'
 fieldMappings:
   field_alternative_title:
     properties:

--- a/config/install/rdf.mapping.node.islandora_object.yml
+++ b/config/install/rdf.mapping.node.islandora_object.yml
@@ -56,6 +56,9 @@ fieldMappings:
     properties:
       - 'dc:subject'
     mapping_type: rel
+  field_weight:
+    properties:
+      - 'schema:position'
   title:
     properties:
       - 'dc:title'

--- a/config/install/views.view.reorder_children.yml
+++ b/config/install/views.view.reorder_children.yml
@@ -5,16 +5,13 @@ dependencies:
     module:
       - islandora_core_feature
   module:
-    - jsonld
     - node
-    - rest
-    - serialization
     - user
     - weight
-id: reorder_members
-label: 'Reorder members'
+id: reorder_children
+label: 'Reorder children'
 module: views
-description: 'Manage members belonging to a piece of content'
+description: 'Re-order children belonging to a piece of content'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -188,7 +185,7 @@ display:
           expose:
             label: ''
           plugin_id: standard
-      title: 'Re-order members'
+      title: 'Re-order children'
       header: {  }
       footer: {  }
       empty: {  }
@@ -253,10 +250,10 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: node/%node/reorder_members
+      path: node/%node/reorder_children
       menu:
         type: tab
-        title: 'Re-order Members'
+        title: 'Re-order Children'
         description: ''
         expanded: false
         parent: ''

--- a/config/install/views.view.reorder_members.yml
+++ b/config/install/views.view.reorder_members.yml
@@ -1,0 +1,276 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - islandora_core_feature
+  module:
+    - jsonld
+    - node
+    - rest
+    - serialization
+    - user
+    - weight
+id: reorder_members
+label: 'Reorder members'
+module: views
+description: 'Manage members belonging to a piece of content'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'manage members'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10, 25, 50, 100'
+            items_per_page_options_all: true
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+      row:
+        type: fields
+      fields:
+        field_weight:
+          id: field_weight
+          table: node__field_weight
+          field: field_weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          range: '1000'
+          plugin_id: weight_selector
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters: {  }
+      sorts:
+        field_weight_value:
+          id: field_weight_value
+          table: node__field_weight
+          field: field_weight_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
+      title: 'Re-order members'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        field_member_of_target_id:
+          id: field_member_of_target_id
+          table: node__field_member_of
+          field: field_member_of_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'not found'
+          validate_options:
+            operation: view
+            multiple: 0
+            bundles: {  }
+            access: false
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: 'Reorder Members Page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: node/%node/reorder_members
+      menu:
+        type: tab
+        title: 'Re-order Members'
+        description: ''
+        expanded: false
+        parent: ''
+        weight: 0
+        context: '0'
+        menu_name: main
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/islandora_defaults.info.yml
+++ b/islandora_defaults.info.yml
@@ -34,4 +34,5 @@ dependencies:
   - text
   - user
   - views
+  - weight
 package: Islandora


### PR DESCRIPTION
# DO NOT MERGE!

We are still _weighing_ the merits of using the weight module over using the standard integer field type with our own drag-n-drop support.

**GitHub Issue**: Islandora-CLAW/CLAW/issues/1262

# What does this Pull Request do?

Changes field_weight from an integer field type to the weight module's weight field type. Adds the weight module as a requirement and updates the rdf mapping. Adds a new "Re-order Members" view and associated tab to provide a drag-n-drop item re-order UI.

# What's new?
* Changes field_weight such that its type changes from integer to weight.
* Added rdf mapping for field_weight as schema:position; adds the schema:CreativeWork type; adds a re-order members view/tab.
* Does this change require documentation to be updated? I don't think we had weight documented yet.
* Does this change add any new dependencies? The [weight module](https://www.drupal.org/project/weight).
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? This requires you to delete the existing weight field before doing a feature import. This will remove any data you have in there, but since the field as added earlier today, we should be okay.
* Could this change impact execution of existing code? No.

# How should this be tested?

- *If you have an existing field_weight*: delete your field_weight.
- apply the PR
- Import the Islandora_defaults feature `drush fim -y islandora_defaults`
- Make an item with a few members.
- Go to the item's "Re-order members" tab and re-order the members as desired. Click "Save" to save the re-order. Optionally, you can click the "Show row weights" link to explicitly set weight values. <img width="751" alt="Screen Shot 2019-09-11 at 8 52 19 AM" src="https://user-images.githubusercontent.com/29869988/64713369-97854f80-d471-11e9-8594-bbc5fab4cd83.png">  _Note:_ this ordering is not used on the "Members" tab as that tab is contained in the islandora module that is unaware of field_weight; but you can add the sort manually.

# Additional Notes:

This setup means that _all_ repository items will have a default field_weight value of '0' which will persist to Fedora as a schema:position value.

# Interested parties
@dannylamb, @dbernstein, @Islandora-CLAW/committers
